### PR TITLE
fix: ensure version numbers are properly handled in version management workflow

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -40,6 +40,11 @@ jobs:
           current_version=${latest_tag#v}
           IFS='.' read -r major minor patch <<< "$current_version"
 
+          # Ensure all parts are treated as numbers
+          major=${major:-0}
+          minor=${minor:-0}
+          patch=${patch:-0}
+
           # Calculate new version
           case $bump_type in
             major)


### PR DESCRIPTION
This PR fixes a bug in the version management workflow where version numbers were not being properly handled, leading to incorrect tag formats. The fix ensures that all version parts (major, minor, patch) are treated as numbers and properly initialized.