### PR TITLE
fix: ensure version bump is calculated correctly

### DIFF
--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -37,6 +37,7 @@ jobs:
           fi
 
           # Get current version numbers
+          latest_tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
           current_version=${latest_tag#v}
           IFS='.' read -r major minor patch <<< "$current_version"
 


### PR DESCRIPTION
This PR fixes a bug in the version management workflow where version bumps were not being calculated correctly. The fix ensures that the latest tag is properly fetched and used for version calculations.