### PR TITLE
ci: enhance release workflow trigger and add debug logging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,13 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      - name: Debug trigger info
+        run: |
+          echo "Event name: ${{ github.event_name }}"
+          echo "Ref name: ${{ github.ref_name }}"
+          echo "Ref type: ${{ github.ref_type }}"
+          echo "SHA: ${{ github.sha }}"
+
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -72,6 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -85,5 +86,8 @@ jobs:
 
       - name: Create and push tag
         run: |
+          echo "Creating tag ${{ needs.version.outputs.new_version }}"
           git tag ${{ needs.version.outputs.new_version }}
+          echo "Pushing tag to origin"
           git push origin ${{ needs.version.outputs.new_version }}
+          echo "Tag pushed successfully"


### PR DESCRIPTION
# Release Workflow Trigger Enhancement

## Problem 🔍

The release workflow was not being triggered when new version tags were pushed by the version workflow. This was due to missing permissions for the `GITHUB_TOKEN`.

## Solution 🛠️

Added the necessary permissions and debug logging to help track the workflow trigger process.

## Changes 📝

- Added `actions:write` permission to create-tag job to allow triggering other workflows
- Added debug logging to tag creation and push process
- Added debug logging to release workflow to track trigger events

## Testing 🧪

The changes can be verified by:
1. Merging this PR
2. Observing the version workflow create and push a new tag
3. Confirming that the release workflow is triggered automatically
4. Checking the debug logs in both workflows