### PR TITLE
ci: fix uv sync extra flag in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install dependencies
         run: |
           uv sync
-          uv sync --extras dev
+          uv sync --extra dev
       - name: Run tests
         run: uv run pytest tests/ -v --cov=src/arborist --cov-report=term-missing
 


### PR DESCRIPTION
## Problem

The release workflow was failing because it used the incorrect flag `--extras` with uv sync, which is not a valid option.

## Solution

Changed the flag to `--extra` to match uv's command line interface.

## Changes

- Modified `.github/workflows/release.yml` to use `--extra` instead of `--extras`

## Testing

After merging, verify the fix by:
1. Running the release workflow manually through GitHub Actions
2. Verifying that all optional dependencies are installed correctly with `uv pip list`
3. Checking the workflow run logs to confirm no flag-related errors

## Changelog Impact

This is a bugfix that corrects a CI workflow issue. No user-facing changes, so no CHANGELOG entry is needed.