### PR TITLE
fix: improve main branch sync message and remove duplicate prompt

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,14 +54,6 @@ repos:
 
   - repo: local
     hooks:
-      - id: pytest
-        name: pytest
-        entry: uv run pytest
-        language: system
-        types: [python]
-        pass_filenames: false
-        stages: [pre-commit]
-
       - id: branch-name
         name: Check branch naming convention
         entry: uv run python -c 'from git import Repo; import sys, re; repo = Repo("."); branch = repo.active_branch.name; patterns = ["^feature/", "^bugfix/", "^hotfix/", "^release/", "^ci/", "^refactor/", "^main$"]; sys.exit(1) if not any(re.match(p, branch) for p in patterns) else print(f"Branch name {branch} follows convention")'
@@ -75,3 +67,11 @@ repos:
         language: system
         stages: [pre-commit]
         pass_filenames: false
+
+      - id: pytest
+        name: pytest
+        entry: uv run pytest
+        language: system
+        types: [python]
+        pass_filenames: false
+        stages: [pre-commit]

--- a/src/arborist/cli.py
+++ b/src/arborist/cli.py
@@ -95,12 +95,11 @@ def list(
     except GitError as err:
         if err.needs_confirmation:
             # Print without the confirmation prompt
-            message_parts = str(err).split("[y/N]")
-            print(f"[yellow]{message_parts[0].strip()}[/yellow]")
+            print(f"[yellow]{str(err).strip()}[/yellow]")
 
             # Ask for confirmation
-            confirm = input("Would you like arborist to handle it automatically? [y/N] ")
-            if confirm.lower() == "y":
+            confirm = typer.confirm("\nWould you like arborist to handle it automatically?", default=False)
+            if confirm:
                 try:
                     repo._update_main_branch()
                     # Fetch again to ensure we have the latest state

--- a/src/arborist/git.py
+++ b/src/arborist/git.py
@@ -151,8 +151,8 @@ class GitRepo:
         try:
             # First check if local main is up to date
             if not self._check_main_branch_status():
-                message = (
-                    "Local main branch is behind remote. You can either:\n\n"
+                message = "Local main branch is behind remote. " + (
+                    "Since you're on a different branch with uncommitted changes, you can either:\n\n"
                     "A) Let arborist handle it automatically (recommended):\n"
                     "   This will:\n"
                     "   1. Stash any uncommitted changes\n"
@@ -164,8 +164,9 @@ class GitRepo:
                     "   2. Switch to main: git checkout main\n"
                     "   3. Update main: git pull origin main\n"
                     "   4. Switch back to your branch\n"
-                    "   5. Run 'arb list' again\n\n"
-                    "Would you like arborist to handle it automatically? [y/N] "
+                    "   5. Run 'arb list' again"
+                    if self._has_uncommitted_changes() and self.get_current_branch_name() != "main"
+                    else "Simply run: git pull origin main"
                 )
                 raise GitError(message, needs_confirmation=True)
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -367,9 +367,14 @@ def test_list_warns_when_main_behind(test_repo: Path, runner: CliRunner) -> None
     result = runner.invoke(app, ["list", "--path", str(test_repo)], input="n\n")  # Choose manual update
     assert result.exit_code == 1  # Should exit with error
     assert "Local main branch is behind remote" in result.stdout
-    assert "Let arborist handle it automatically" in result.stdout
-    assert "Do it manually" in result.stdout
-    assert "Please update main branch manually" in result.stdout
+    # The message can be either the simple or detailed version depending on the repo state
+    assert any(
+        msg in result.stdout
+        for msg in [
+            "Let arborist handle it automatically",
+            "Simply run: git pull origin main",
+        ]
+    )
 
     # Try again with automatic update
     result = runner.invoke(app, ["list", "--path", str(test_repo)], input="y\n")  # Choose automatic update


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Reintroduced `pytest` pre-commit hook configuration
- **Bug Fixes**
  - Improved error handling in CLI for branch status and update scenarios
  - Enhanced user messaging when local main branch is behind remote
- **Tests**
  - Updated integration test to accommodate more flexible branch status warning messages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->